### PR TITLE
Fix .git file corruption issue on windows

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-find . -type f -exec sed -i 's/{dockerHubUsername}/'$1'/g' {} +
+find . -type f ! -path "./.git/*" -exec sed -i 's/{dockerHubUsername}/'$1'/g' {} +


### PR DESCRIPTION
The script was corrupting the files on windows not sure if on linux as well please add this change to ignore the .git folder from the script so student don't have this issue as well.

<!-- This repository *does not* accept pull requests (PRs). All pull requests will be closed. See CONTRIBUTING.md for further details. -->
